### PR TITLE
Add blog and code for Jerikan, a YAML/Jinja2/Ansible CMDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,12 +343,12 @@ models that enable capacity planning, network optimization and what-if scenario 
 - [TeemIP](https://sourceforge.net/projects/teemip/) - TeemIp is an open source, WEB based, IP Adress Management (IPAM) tool that provides comprehensive IP Management capabilities. It allows you to manage your IPv4 and IPv6 spaces through a simple and powerful user interface: track user requests, discover and allocate IPs, manage your IP plan and your subnet space in accordance with best in class IP Management practices.
 
 # Configuration Management
+- [Jerikan](https://github.com/jerikan-network/cmdb) - Network wide CMDB combining single source of truth in YAML, configs in Jinja2 and deployment with Ansible.
 - [ManageEngine](https://www.manageengine.com/network-configuration-manager/) - Network Configuration Manager is a multi vendor network change, configuration and compliance management (NCCCM) solution for switches, routers, firewalls and other network devices.
 - [NetMRI](https://www.infoblox.com/products/netmri/) - Vendor Agnostic NCCM tool with with policy engine and multi-vendor device lifecycle/vulnerability management. (Infoblox product)
-- [Solarwinds](https://www.solarwinds.com/network-configuration-manager) - Automated network configuration and compliance management.
 - [Rconfig](https://www.rconfig.com/) - Free, open source network device configuration management tool, customizable to your needs!
+- [Solarwinds](https://www.solarwinds.com/network-configuration-manager) - Automated network configuration and compliance management.
 - [Unimus](https://unimus.net) - Network-wide configuration search and config diff over time in an easy to use web GUI.
-- [Jerikan](https://github.com/jerikan-network/cmdb) - Network wide CMDB combining single source of truth in YAML, configs in Jinja2 and deployment with Ansible.
 
 # Books
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Network Automation is a cross between the discipline of [Network Infrastructure]
 - [Packet Life](http://packetlife.net/) - The Network Automation thoughts of Jeremy Stretch.
 - [Python for Network Engineers](https://pynet.twb-tech.com/blog/) - Articles on Netmiko, NAPALM, and Ansible by Kirk Byers.
 - [Scott Lowe](https://blog.scottlowe.org) - The Network Automation thoughts of Scott Lowe.
+- [MTU Ninja](https://vincent.bernat.ch/en/blog#tag-network-automation) - The Network Automation thoughts of Vincent Bernat.
 
 # Programming Topics
 
@@ -347,6 +348,7 @@ models that enable capacity planning, network optimization and what-if scenario 
 - [Solarwinds](https://www.solarwinds.com/network-configuration-manager) - Automated network configuration and compliance management.
 - [Rconfig](https://www.rconfig.com/) - Free, open source network device configuration management tool, customizable to your needs!
 - [Unimus](https://unimus.net) - Network-wide configuration search and config diff over time in an easy to use web GUI.
+- [Jerikan+Ansible](https://github.com/jerikan-network/cmdb) - Network wide CMDB combining single source of truth in YAML, configs in Jinja2 and deployment with Ansible.  [Detailed blog post with examples](https://vincent.bernat.ch/en/blog/2021-network-jerikan-ansible).
 
 # Books
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Network Automation is a cross between the discipline of [Network Infrastructure]
 - [Jason Edelman](http://www.jedelman.com/) - The Network Automation thoughts of Jason Edelman.
 - [Josh-V](https://josh-v.com/) - The Network Automation thoughts of Josh VanDeraa.
 - [Mircea Ulinic](https://mirceaulinic.net/) - Random thoughts of Mircea Ulinic. May include event-driven network automation, vendor bashing or machine learning (TBD).
+- [MTU Ninja](https://vincent.bernat.ch/en/blog#tag-network-automation) - The Network Automation thoughts of Vincent Bernat.
 - [Napalm-automation](https://napalm-automation.net/blog/) - News and updates about the NAPALM project.
 - [Network to Code](https://blog.networktocode.com/) - Network to Code's blog sharing thoughts, ideas, and tips all about network automation.
 - [Networklore](https://networklore.com/blog) - The Network Automation thoughts of Patrick Ogenstad.
@@ -101,7 +102,6 @@ Network Automation is a cross between the discipline of [Network Infrastructure]
 - [Packet Life](http://packetlife.net/) - The Network Automation thoughts of Jeremy Stretch.
 - [Python for Network Engineers](https://pynet.twb-tech.com/blog/) - Articles on Netmiko, NAPALM, and Ansible by Kirk Byers.
 - [Scott Lowe](https://blog.scottlowe.org) - The Network Automation thoughts of Scott Lowe.
-- [MTU Ninja](https://vincent.bernat.ch/en/blog#tag-network-automation) - The Network Automation thoughts of Vincent Bernat.
 
 # Programming Topics
 
@@ -348,7 +348,7 @@ models that enable capacity planning, network optimization and what-if scenario 
 - [Solarwinds](https://www.solarwinds.com/network-configuration-manager) - Automated network configuration and compliance management.
 - [Rconfig](https://www.rconfig.com/) - Free, open source network device configuration management tool, customizable to your needs!
 - [Unimus](https://unimus.net) - Network-wide configuration search and config diff over time in an easy to use web GUI.
-- [Jerikan+Ansible](https://github.com/jerikan-network/cmdb) - Network wide CMDB combining single source of truth in YAML, configs in Jinja2 and deployment with Ansible.  [Detailed blog post with examples](https://vincent.bernat.ch/en/blog/2021-network-jerikan-ansible).
+- [Jerikan](https://github.com/jerikan-network/cmdb) - Network wide CMDB combining single source of truth in YAML, configs in Jinja2 and deployment with Ansible.
 
 # Books
 


### PR DESCRIPTION
* The blog has a bunch of networking and networking automation posts.
  Linked to the specific tag.
* Jerikan was the tool built for managing Blade's networking
  infrastructure, the company operating Shadow, a cloud computing
product.  Here's the blurb about it:
 > Our network was around 800 devices, spanning over 10 datacenters with more than 2.5 Tbps of available egress bandwidth. The released material is therefore a substantial example of managing a medium-scale network using Ansible. We have left out the handling of our legacy datacenters to make the final result more readable while keeping enough material to not turn it into a trivial example.

If there is a better section for this, feel free to suggest a better location.  It's more than just Ansible, but there isn't a `misc` section for other config management.

I saw this on [lobste.rs](https://lobste.rs/s/agyk0d/jerikan_configuration_management) and it is the work of @vincentbernat.