### PR TITLE
OSPF watcher tool is added

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,8 @@ Network Automation is a cross between the discipline of [Network Infrastructure]
 - [Network-Conditions-Emulator](https://github.com/marty90/Network-Conditions-Emulator) - Artificially limit bandwidth, delay and loss rate on selected interfaces.
 - [netconan](https://github.com/intentionet/netconan) - Network Configuration Anonymizer
 - [NetCopa](https://github.com/cidrblock/netcopa) - Network device configuration parser ("industry standard" -> YAML converter).
-- [Topolograph](https://github.com/Vadims06/topolograph) - Python-based Web tool for visualisation of OSPF topologies and making a prediction of network behaviour in case of network's outage.
+- [Topolograph](https://github.com/Vadims06/topolograph) - Python-based Web tool for visualisation of OSPF/ISIS topologies and making a prediction of network behaviour in case of network's outage.
+- [OSPF Watcher](https://github.com/Vadims06/ospfwatcher) - Container-based solution which tracks OSPF topology changes via established GRE tunnel with the network and shows them on the history diagram. Helps to clarify what has happened with the network 5 min or 5 hours ago.
 
 # Hypervisors and Containers
 

--- a/README.md
+++ b/README.md
@@ -331,8 +331,8 @@ Network Automation is a cross between the discipline of [Network Infrastructure]
 - [Network-Conditions-Emulator](https://github.com/marty90/Network-Conditions-Emulator) - Artificially limit bandwidth, delay and loss rate on selected interfaces.
 - [netconan](https://github.com/intentionet/netconan) - Network Configuration Anonymizer
 - [NetCopa](https://github.com/cidrblock/netcopa) - Network device configuration parser ("industry standard" -> YAML converter).
+- [OSPF Watcher](https://github.com/Vadims06/ospfwatcher) - Tracks OSPF topology changes--by establishing a GRE tunnel with network devices--via a history diagram.
 - [Topolograph](https://github.com/Vadims06/topolograph) - Python-based Web tool for visualisation of OSPF/ISIS topologies and making a prediction of network behaviour in case of network's outage.
-- [OSPF Watcher](https://github.com/Vadims06/ospfwatcher) - Container-based solution which tracks OSPF topology changes via established GRE tunnel with the network and shows them on the history diagram. Helps to clarify what has happened with the network 5 min or 5 hours ago.
 
 # Hypervisors and Containers
 


### PR DESCRIPTION
OSPF Watcher tool allows to parse OSPF debug messages, convert them into structured format and export to Elastic Search Engine. As a result, it tracks any up/down OSPF neighbor adjacency changes, link cost changes and new subnets appearance/disappearance from the topology