### PR TITLE
Add NetPilot to Network Emulators

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,7 @@ Network Automation is a cross between the discipline of [Network Infrastructure]
 
  - [GNS3](https://www.gns3.com/) - Graphical Network Simulator-3.
  - [Mininet](http://mininet.org/) - Mininet creates a realistic virtual network, running real kernel, switch and application code, on a single machine (VM, cloud or native), in seconds, with a single command.
+ - [NetPilot](https://netpilot.io) - AI agent for network labs. Describe any network in plain English; the agent builds topology, generates vendor-specific configs (Cisco, Juniper, Arista, Nokia, Palo Alto, Fortinet), and deploys to cloud with real CLIs — in 2 minutes.
  - [netlab](https://github.com/ipspace/netlab) - Brings infrastructure-as-code concepts to networking labs. You'll describe your high-level network topology and routing design in a YAML file, and the tools in this repository will create configs for VirtualBox/libvirt/containerlab, Ansible inventory, IPv4/v6 addressing, VLANs and VRFs, OSPF, EIGRP, IS-IS, BGP, BFD, MPLS, MPLS/VPN, VXLAN, EVPN and Segment Routing.
  - [UNetLab](https://www.routereflector.com/unetlab/) - Unified Networking Lab.
  - [VRNetLab](https://github.com/plajjan/vrnetlab) - Run your favourite virtual routers in docker for convenient labbing, development and testing.


### PR DESCRIPTION
Adds NetPilot to the Network Emulators section.

NetPilot is an AI agent that designs, builds, and validates multi-vendor network labs from a plain-English prompt. It runs real NOS images (9+ vendors and growing — Cisco IOL/XRd/NX-OS, Juniper cRPD, Arista cEOS, Nokia SR Linux, Palo Alto, Fortinet, Aruba AOS-CX, FRR) on containerlab-based cloud sandboxes with real device CLIs.

Website: https://netpilot.io

_Updated 2026-08-23: refreshed the entry description to current NOS coverage._