### PR TITLE
Add mediacast-netcatalog (multi-vendor command catalog + version matcher)

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@ Network Automation is a cross between the discipline of [Network Infrastructure]
  - [f5-common-python](https://github.com/F5Networks/f5-common-python) - Python SDK for configuration and monitoring of F5 BIG-IP devices via the iControl REST API.
  - [Infoblox Python Module](https://github.com/infobloxopen/infoblox-client) - Python wrapper for REST API
  - [Infoblox Go Client](https://github.com/infobloxopen/infoblox-go-client) - Go wrapper for REST API
+ - [mediacast-netcatalog](https://github.com/Mediacastnet/mediacast-netcatalog) - Vendor command catalog + version matcher + protocol probe for multi-vendor network switches (Cisco IOS-XE/NX-OS, Aruba AOS-CX, Juniper Junos, Arista EOS, HPE ProCurve, Cisco Meraki MS). Rust core with Python bindings via PyO3.
  - [pan-python](https://github.com/kevinsteves/pan-python) - Multi-tool set for Palo Alto Networks PAN-OS, Panorama, WildFire and AutoFocus.
  - [pandevice](https://github.com/PaloAltoNetworks/pan-os-python) - Device framework for interacting with Palo Alto Networks devices.
  - [pyeapi](https://github.com/arista-eosplus/pyeapi) - Python library for Arista EOS.


### PR DESCRIPTION
## What

Adds [mediacast-netcatalog](https://github.com/Mediacastnet/mediacast-netcatalog) to the **Vendor Abstraction Library** section.

## Why it fits this list

A YAML-backed catalog mapping abstract command types (ARP_TABLE, MAC_TABLE, INTERFACE_CONFIG, etc.) to concrete CLI strings + protocol alternatives (NETCONF / RESTCONF / gNMI / eAPI / SNMP / Dashboard API) per `(vendor, firmware version)` for seven switch platforms:

- Cisco IOS / IOS-XE
- Cisco NX-OS
- Aruba AOS-CX
- Juniper Junos
- Arista EOS
- HPE / Aruba ProCurve
- Cisco Meraki MS

Catches the real-world version-aware traps that bite multi-vendor automation:

- Cisco IOS-XE 12.x / 15.x / 17.x output drift on the same `show` command
- NX-OS `ip dhcp relay address` vs. IOS `ip helper-address`
- Aruba AOS-CX firmware family-prefix versioning (`FL.10.13.1000` etc.)
- Junos transactional config (`configure → set → commit` not single-line imperative)
- Arista EOS defaults (MSTP, MTU 9214) that differ from the IOS-compatible CLI surface

## Distribution

- [crates.io](https://crates.io/crates/mediacast-netcatalog) (Rust)
- [PyPI](https://pypi.org/project/mediacast-netcatalog/) (Python via PyO3 bindings)
- Dual-licensed MIT / Apache-2.0
- Currently v0.2 (API may evolve toward v1.0; pin a specific minor version)

## Existing-entry alphabetical fit

Placed between `Infoblox Go Client` and `pan-python` to maintain the section's alphabetical order.