### PR TITLE
Add TopoAI to the network tools list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,7 @@ Network Automation is a cross between the discipline of [Network Infrastructure]
 - [NetCopa](https://github.com/cidrblock/netcopa) - Network device configuration parser ("industry standard" -> YAML converter).
 - [NetTowel](https://github.com/InfrastructureAsCode-ch/nettowel) - Collection of useful network automation functions for the CLI.
 - [OSPF Watcher](https://github.com/Vadims06/ospfwatcher) - Tracks OSPF topology changes by establishing a GRE tunnel with network devices via a history diagram.
+- [TopoAI](https://www.topoai.cc/) - AI-assisted network topology diagram first drafts from sanitized natural-language infrastructure scenarios, ready for draw.io refinement.
 - [Topolograph](https://github.com/Vadims06/topolograph) - Python-based Web tool for visualisation of OSPF/ISIS topologies and making a prediction of network behaviour in case of network's outage.
 
 ## Network Telemetry


### PR DESCRIPTION
Adds TopoAI under Tools as an AI-assisted first-draft option for network topology diagrams.

Why I think it fits this list:
- Network automation teams often need topology diagrams during design reviews, change planning, documentation, and handoffs.
- TopoAI is not a configuration automation platform; it helps turn sanitized infrastructure scenarios into an editable topology draft before draw.io refinement.
- This is closest to the existing diagram/documentation-adjacent tools such as D2, Drawthe.net, and Topolograph.